### PR TITLE
Add first batch of unit tests for Core files

### DIFF
--- a/APIClient.xcodeproj/project.pbxproj
+++ b/APIClient.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5E426F081E57584A005C4C12 /* APIClient+Genome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E426F071E57584A005C4C12 /* APIClient+Genome.swift */; };
 		5E54CFFC1E2E927100F3ABE1 /* APIClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E54CFF21E2E927100F3ABE1 /* APIClient.framework */; };
 		5E54D0011E2E927100F3ABE1 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E54D0001E2E927100F3ABE1 /* APIClientTests.swift */; };
+		5EF7831F1E687E010066FA24 /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF7831E1E687E010066FA24 /* RequestTests.swift */; };
 		BB63FD0EF047E27D9084DE31 /* Pods_APIClientTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F7D916833F4B0DF1AE4D3D1 /* Pods_APIClientTests.framework */; };
 		D88F865C05B4384FD2937338 /* Pods_APIClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17B24F0D96C0CDC515E696FD /* Pods_APIClient.framework */; };
 /* End PBXBuildFile section */
@@ -38,6 +39,7 @@
 		5E54CFFB1E2E927100F3ABE1 /* APIClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = APIClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E54D0001E2E927100F3ABE1 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		5E54D0021E2E927100F3ABE1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5EF7831E1E687E010066FA24 /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		7D8D16CD3CDD9595245D801E /* Pods-APIClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-APIClientTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-APIClientTests/Pods-APIClientTests.release.xcconfig"; sourceTree = "<group>"; };
 		DC836426EC10CC75E74ED961 /* Pods-APIClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-APIClient.release.xcconfig"; path = "Pods/Target Support Files/Pods-APIClient/Pods-APIClient.release.xcconfig"; sourceTree = "<group>"; };
 		EE91157109E5FD971BC09B5B /* Pods-APIClientTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-APIClientTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-APIClientTests/Pods-APIClientTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				5E54D0001E2E927100F3ABE1 /* APIClientTests.swift */,
+				5EF7831E1E687E010066FA24 /* RequestTests.swift */,
 				5E54D0021E2E927100F3ABE1 /* Info.plist */,
 			);
 			path = Tests;
@@ -345,6 +348,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EF7831F1E687E010066FA24 /* RequestTests.swift in Sources */,
 				5E54D0011E2E927100F3ABE1 /* APIClientTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/APIClient.xcodeproj/project.pbxproj
+++ b/APIClient.xcodeproj/project.pbxproj
@@ -510,7 +510,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = THP5EV5EJ9;
-				INFOPLIST_FILE = APIClientTests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.intrepid.APIClientTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -524,7 +524,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = THP5EV5EJ9;
-				INFOPLIST_FILE = APIClientTests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.intrepid.APIClientTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Source/APIClient/APIClient.swift
+++ b/Source/APIClient/APIClient.swift
@@ -38,17 +38,19 @@ open class APIClient {
     internal func result(data: Data?, response: URLResponse?, error: Error?) -> Result<Data?> {
         if let error = error {
             return .failure(APIClientError.dataTaskError(error: error))
-        } else if let httpResponse = response as? HTTPURLResponse {
-            let statusCode = httpResponse.statusCode
-            switch statusCode {
-            case 200..<300:
-                return .success(data)
-            default:
-                let error = APIClientError.httpError(statusCode: statusCode, response: httpResponse, data: data)
-                return .failure(error)
-            }
-        } else {
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
             return .failure(APIClientError.unknown)
+        }
+
+        let statusCode = httpResponse.statusCode
+        switch statusCode {
+        case 200..<300:
+            return .success(data)
+        default:
+            let error = APIClientError.httpError(statusCode: statusCode, response: httpResponse, data: data)
+            return .failure(error)
         }
     }
 }

--- a/Source/APIClient/Request.swift
+++ b/Source/APIClient/Request.swift
@@ -18,31 +18,17 @@ public enum HTTPMethod: String {
 public protocol Request {
     static var baseURL: String { get }
     static var acceptHeader: String? { get }
-    static var authToken: String? { get set }
+    static var authToken: String? { get }
 
     var method: HTTPMethod { get }
     var path: String { get }
     var authenticated: Bool { get }
-    var queryParameters: [String: AnyObject]? { get }
-    var bodyParameters: [String: AnyObject]? { get }
+    var queryParameters: [String: Any]? { get }
+    var bodyParameters: [String: Any]? { get }
     var contentType: String { get }
-
-    var urlRequest: URLRequest { get }
-
-    func encodeQueryParameters(request: NSMutableURLRequest, parameters: [String : AnyObject]?)
-    func encodeHTTPBody(request: NSMutableURLRequest, parameters: [String : AnyObject]?)
 }
 
 public extension Request {
-
-    static var acceptHeader: String? { return nil }
-
-    var contentType: String {
-        switch self {
-        default:
-            return "application/json"
-        }
-    }
 
     var urlRequest: URLRequest {
         let baseURL = Foundation.URL(string: Self.baseURL)!
@@ -68,7 +54,7 @@ public extension Request {
         return request as URLRequest
     }
 
-    func encodeQueryParameters(request: NSMutableURLRequest, parameters: [String : AnyObject]?) {
+    private func encodeQueryParameters(request: NSMutableURLRequest, parameters: [String : Any]?) {
         guard let url = request.url,
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
             let stringParameters = parameters as? [String : String]
@@ -86,7 +72,7 @@ public extension Request {
         request.url = components.url
     }
 
-    func encodeHTTPBody(request: NSMutableURLRequest, parameters: [String : AnyObject]?) {
+    private func encodeHTTPBody(request: NSMutableURLRequest, parameters: [String : Any]?) {
         guard let parameters = parameters else { return }
 
         do {

--- a/Tests/APIClientTests.swift
+++ b/Tests/APIClientTests.swift
@@ -10,27 +10,35 @@ import XCTest
 @testable import APIClient
 
 class APIClientTests: XCTestCase {
-    
+
+    let testURL = URL(string: "intrepid.io")!
+    var sut: APIClient!
+
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        sut = APIClient()
     }
     
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        sut = nil
         super.tearDown()
     }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+
+    func testDataTaskErrorResult() {
+        let error = NSError()
+        let result = sut.result(data: nil, response: nil, error: error)
+        XCTAssert(result.isFailure)
     }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+
+    func testSuccessResult() {
+        let response = HTTPURLResponse(url: testURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+        let result = sut.result(data: nil, response: response, error: nil)
+        XCTAssert(result.isSuccess)
     }
-    
+
+    func testStatusCodeErrorResult() {
+        let response = HTTPURLResponse(url: testURL, statusCode: 400, httpVersion: nil, headerFields: nil)
+        let result = sut.result(data: nil, response: response, error: nil)
+        XCTAssert(result.isFailure)
+    }
 }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1,0 +1,83 @@
+//
+//  RequestTests.swift
+//  APIClient
+//
+//  Created by Mark Daigneault on 3/2/17.
+//  Copyright © 2017 Mark Daigneault. All rights reserved.
+//
+
+import XCTest
+@testable import APIClient
+
+struct TestRequest: Request {
+
+    static var baseURL: String {
+        return "http://intrepid.io"
+    }
+
+    static var acceptHeader: String? {
+        return "application/json"
+    }
+
+    static var authToken: String? {
+        return "test-token"
+    }
+
+    var method: HTTPMethod {
+        return .GET
+    }
+
+    var path: String {
+        return "test"
+    }
+
+    var authenticated: Bool {
+        return true
+    }
+
+    var queryParameters: [String : Any]? {
+        return [
+            "param1" : 1,
+            "param2" : 2
+        ]
+    }
+
+    var bodyParameters: [String : Any]? {
+        return [
+            "object" : [
+                "id" : 1,
+                "name" : "test"
+            ]
+        ]
+    }
+
+    var contentType: String {
+        return "application/json"
+    }
+}
+
+class RequestTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}


### PR DESCRIPTION
Unit tests for `APIClient` and `Request`
- Had to refactor `APIClient` a bit to expose response handling in a dedicated function