### PR TITLE
Authentication Layer

### DIFF
--- a/APIClient.xcodeproj/project.pbxproj
+++ b/APIClient.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@
 		5E426F081E57584A005C4C12 /* APIClient+Genome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E426F071E57584A005C4C12 /* APIClient+Genome.swift */; };
 		5E54CFFC1E2E927100F3ABE1 /* APIClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E54CFF21E2E927100F3ABE1 /* APIClient.framework */; };
 		5E54D0011E2E927100F3ABE1 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E54D0001E2E927100F3ABE1 /* APIClientTests.swift */; };
+		5EDDC87F1E6DDE6400584797 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDDC87E1E6DDE6400584797 /* Authentication.swift */; };
+		5EDDC8821E6DE3A300584797 /* MockRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDDC8811E6DE3A300584797 /* MockRequest.swift */; };
+		5EDDC8841E6DE49900584797 /* MockMappableObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDDC8831E6DE49900584797 /* MockMappableObject.swift */; };
+		5EDDC8861E6DE71100584797 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDDC8851E6DE71100584797 /* AuthenticationTests.swift */; };
+		5EDDC8881E6DE75300584797 /* MockAuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDDC8871E6DE75300584797 /* MockAuthClient.swift */; };
+		5EDDC88A1E6DE90300584797 /* MockAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDDC8891E6DE90300584797 /* MockAPIClient.swift */; };
 		5EF7831F1E687E010066FA24 /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF7831E1E687E010066FA24 /* RequestTests.swift */; };
 		BB63FD0EF047E27D9084DE31 /* Pods_APIClientTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F7D916833F4B0DF1AE4D3D1 /* Pods_APIClientTests.framework */; };
 		D88F865C05B4384FD2937338 /* Pods_APIClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17B24F0D96C0CDC515E696FD /* Pods_APIClient.framework */; };
@@ -43,6 +49,12 @@
 		5EDDC44E1E69D87900584797 /* Intrepid.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intrepid.framework; path = "../../Library/Developer/Xcode/DerivedData/APIClient-aubiaoakqafdsofzmotihgcvpzvp/Build/Products/Debug-iphonesimulator/Intrepid/Intrepid.framework"; sourceTree = "<group>"; };
 		5EDDC44F1E69D87900584797 /* IP_UIKit_Wisdom.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IP_UIKit_Wisdom.framework; path = "../../Library/Developer/Xcode/DerivedData/APIClient-aubiaoakqafdsofzmotihgcvpzvp/Build/Products/Debug-iphonesimulator/IP-UIKit-Wisdom/IP_UIKit_Wisdom.framework"; sourceTree = "<group>"; };
 		5EDDC4651E69D9B600584797 /* Pods_APIClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_APIClient.framework; path = "../../Library/Developer/Xcode/DerivedData/APIClient-aubiaoakqafdsofzmotihgcvpzvp/Build/Products/Debug-iphonesimulator/Pods_APIClient.framework"; sourceTree = "<group>"; };
+		5EDDC87E1E6DDE6400584797 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
+		5EDDC8811E6DE3A300584797 /* MockRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRequest.swift; sourceTree = "<group>"; };
+		5EDDC8831E6DE49900584797 /* MockMappableObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMappableObject.swift; sourceTree = "<group>"; };
+		5EDDC8851E6DE71100584797 /* AuthenticationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
+		5EDDC8871E6DE75300584797 /* MockAuthClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAuthClient.swift; sourceTree = "<group>"; };
+		5EDDC8891E6DE90300584797 /* MockAPIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAPIClient.swift; sourceTree = "<group>"; };
 		5EF7831E1E687E010066FA24 /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		7D8D16CD3CDD9595245D801E /* Pods-APIClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-APIClientTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-APIClientTests/Pods-APIClientTests.release.xcconfig"; sourceTree = "<group>"; };
 		DC836426EC10CC75E74ED961 /* Pods-APIClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-APIClient.release.xcconfig"; path = "Pods/Target Support Files/Pods-APIClient/Pods-APIClient.release.xcconfig"; sourceTree = "<group>"; };
@@ -94,6 +106,7 @@
 			children = (
 				5E426F011E57583D005C4C12 /* APIClient.swift */,
 				5E426F031E57583D005C4C12 /* Request.swift */,
+				5EDDC87E1E6DDE6400584797 /* Authentication.swift */,
 			);
 			path = APIClient;
 			sourceTree = "<group>";
@@ -131,11 +144,24 @@
 		5E54CFFF1E2E927100F3ABE1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				5EDDC8801E6DE37800584797 /* Mocks */,
 				5E54D0001E2E927100F3ABE1 /* APIClientTests.swift */,
 				5EF7831E1E687E010066FA24 /* RequestTests.swift */,
+				5EDDC8851E6DE71100584797 /* AuthenticationTests.swift */,
 				5E54D0021E2E927100F3ABE1 /* Info.plist */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		5EDDC8801E6DE37800584797 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				5EDDC8891E6DE90300584797 /* MockAPIClient.swift */,
+				5EDDC8811E6DE3A300584797 /* MockRequest.swift */,
+				5EDDC8831E6DE49900584797 /* MockMappableObject.swift */,
+				5EDDC8871E6DE75300584797 /* MockAuthClient.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		74D222312F3132A823DB0FE1 /* Frameworks */ = {
@@ -350,6 +376,7 @@
 				5E426F081E57584A005C4C12 /* APIClient+Genome.swift in Sources */,
 				5E426F061E57583D005C4C12 /* Request.swift in Sources */,
 				5E426F041E57583D005C4C12 /* APIClient.swift in Sources */,
+				5EDDC87F1E6DDE6400584797 /* Authentication.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -359,6 +386,11 @@
 			files = (
 				5EF7831F1E687E010066FA24 /* RequestTests.swift in Sources */,
 				5E54D0011E2E927100F3ABE1 /* APIClientTests.swift in Sources */,
+				5EDDC8841E6DE49900584797 /* MockMappableObject.swift in Sources */,
+				5EDDC88A1E6DE90300584797 /* MockAPIClient.swift in Sources */,
+				5EDDC8861E6DE71100584797 /* AuthenticationTests.swift in Sources */,
+				5EDDC8881E6DE75300584797 /* MockAuthClient.swift in Sources */,
+				5EDDC8821E6DE3A300584797 /* MockRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/APIClient/Authentication.swift
+++ b/Source/APIClient/Authentication.swift
@@ -1,0 +1,64 @@
+//
+//  AuthTokenRefresher.swift
+//  APIClient
+//
+//  Created by Mark Daigneault on 3/3/17.
+//  Copyright © 2017 Mark Daigneault. All rights reserved.
+//
+
+import Foundation
+import Intrepid
+
+public protocol AuthClient {
+    func login(email: String, password: String, completion: ((Result<String>) -> Void)?)
+}
+
+public protocol CredentialProviding {
+    var email: String? { get set }
+    var password: String? { get set }
+    var token: String? { get set }
+
+    var formattedToken: String? { get }
+}
+
+public enum AuthTokenRefreshError: Error {
+    case MissingCredentials
+    case AuthenticationError(Error)
+}
+
+public class AuthTokenRefresher {
+
+    let apiClient: APIClient
+    let authClient: AuthClient
+    var credentialProvider: CredentialProviding
+
+    init(apiClient: APIClient, authClient: AuthClient, credentialProvider: CredentialProviding) {
+        self.apiClient = apiClient
+        self.authClient = authClient
+        self.credentialProvider = credentialProvider
+    }
+
+    func handleUnauthorizedRequest(request: URLRequest, completion: ((Result<Data?>) -> Void)?) {
+        guard
+            let email = credentialProvider.email,
+            let password = credentialProvider.password
+        else {
+            completion?(.failure(AuthTokenRefreshError.MissingCredentials))
+            return
+        }
+
+        authClient.login(email: email, password: password) { [weak self] result in
+            guard let welf = self else { return }
+            switch result {
+            case .success(let token):
+                welf.credentialProvider.token = token
+                var mutableRequest = request
+                mutableRequest.setValue(welf.credentialProvider.formattedToken, forHTTPHeaderField: "Authorization")
+                welf.apiClient.sendRequest(mutableRequest, completion: completion)
+            case .failure(let error):
+                welf.credentialProvider.token = nil
+                completion?(.failure(AuthTokenRefreshError.AuthenticationError(error)))
+            }
+        }
+    }
+}

--- a/Source/APIClient/Request.swift
+++ b/Source/APIClient/Request.swift
@@ -18,7 +18,6 @@ public enum HTTPMethod: String {
 public protocol Request {
     static var baseURL: String { get }
     static var acceptHeader: String? { get }
-    static var authorizationHeader: String? { get }
 
     var method: HTTPMethod { get }
     var path: String { get }
@@ -26,6 +25,7 @@ public protocol Request {
     var queryParameters: [String: Any]? { get }
     var bodyParameters: [String: Any]? { get }
     var contentType: String { get }
+    var credentialProvider: CredentialProviding? { get }
 }
 
 public extension Request {
@@ -41,11 +41,7 @@ public extension Request {
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
 
         if authenticated {
-            if let authorizationHeader = Self.authorizationHeader {
-                request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
-            } else {
-                print("Error: authenticated request missing token: %@", request)
-            }
+            request.setValue(credentialProvider?.formattedToken, forHTTPHeaderField: "Authorization")
         }
 
         encodeQueryParameters(request: request, parameters: queryParameters)

--- a/Source/APIClient/Request.swift
+++ b/Source/APIClient/Request.swift
@@ -34,23 +34,23 @@ public extension Request {
         let baseURL = Foundation.URL(string: Self.baseURL)!
         let url = Foundation.URL(string: path, relativeTo: baseURL) ?? baseURL
 
-        let request = NSMutableURLRequest(url: url)
+        var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
 
         request.setValue(Self.acceptHeader, forHTTPHeaderField: "Accept")
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
 
         if authenticated {
-            request.setValue(credentialProvider?.formattedToken, forHTTPHeaderField: "Authorization")
+            credentialProvider?.authorizeRequest(&request)
         }
 
-        encodeQueryParameters(request: request, parameters: queryParameters)
-        encodeHTTPBody(request: request, parameters: bodyParameters)
+        encodeQueryParameters(request: &request, parameters: queryParameters)
+        encodeHTTPBody(request: &request, parameters: bodyParameters)
 
         return request as URLRequest
     }
 
-    private func encodeQueryParameters(request: NSMutableURLRequest, parameters: [String : Any]?) {
+    private func encodeQueryParameters(request: inout URLRequest, parameters: [String : Any]?) {
         guard let url = request.url,
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
             let stringParameters = parameters as? [String : String]
@@ -68,7 +68,7 @@ public extension Request {
         request.url = components.url
     }
 
-    private func encodeHTTPBody(request: NSMutableURLRequest, parameters: [String : Any]?) {
+    private func encodeHTTPBody(request: inout URLRequest, parameters: [String : Any]?) {
         guard let parameters = parameters else { return }
 
         do {

--- a/Tests/APIClientTests.swift
+++ b/Tests/APIClientTests.swift
@@ -14,6 +14,8 @@ import Genome
 class APIClientTests: XCTestCase {
 
     let testURL = URL(string: "intrepid.io")!
+    let testRequest = TestRequest().urlRequest
+
     var sut: APIClient!
 
     override func setUp() {
@@ -30,20 +32,20 @@ class APIClientTests: XCTestCase {
 
     func testDataTaskErrorResult() {
         let error = NSError()
-        let result = sut.result(data: nil, response: nil, error: error)
-        XCTAssert(result.isFailure)
+        let result = sut.result(request: testRequest, completion: nil, data: nil, response: nil, error: error)
+        XCTAssert(result!.isFailure)
     }
 
     func testSuccessResult() {
         let response = HTTPURLResponse(url: testURL, statusCode: 200, httpVersion: nil, headerFields: nil)
-        let result = sut.result(data: nil, response: response, error: nil)
-        XCTAssert(result.isSuccess)
+        let result = sut.result(request: testRequest, completion: nil, data: nil, response: response, error: nil)
+        XCTAssert(result!.isSuccess)
     }
 
     func testStatusCodeErrorResult() {
         let response = HTTPURLResponse(url: testURL, statusCode: 400, httpVersion: nil, headerFields: nil)
-        let result = sut.result(data: nil, response: response, error: nil)
-        XCTAssert(result.isFailure)
+        let result = sut.result(request: testRequest, completion: nil, data: nil, response: response, error: nil)
+        XCTAssert(result!.isFailure)
     }
 
     // MARK: - Genome
@@ -57,7 +59,7 @@ class APIClientTests: XCTestCase {
         let json = ["identifier" : "1", "name" : "test"]
         do {
             let data = try JSONSerialization.data(withJSONObject: json, options: [])
-            let success: Result<MockMappableObject> = sut.mappableObjectResult(dataResult: .success(data))
+            let success: Result<MockMappableObject> = sut.mappableObjectResult(keyPath: nil, dataResult: .success(data))
             let mappedObject = success.value
             XCTAssertEqual(mappedObject?.identifier, "1")
             XCTAssertEqual(mappedObject?.name, "test")
@@ -73,7 +75,7 @@ class APIClientTests: XCTestCase {
         ]
         do {
             let data = try JSONSerialization.data(withJSONObject: json, options: [])
-            let success: Result<[MockMappableObject]> = sut.mappableArrayResult(dataResult: .success(data))
+            let success: Result<[MockMappableObject]> = sut.mappableArrayResult(keyPath: nil, dataResult: .success(data))
             let array = success.value
             XCTAssertEqual(array?[0].identifier, "1")
             XCTAssertEqual(array?[0].name, "test")
@@ -82,15 +84,5 @@ class APIClientTests: XCTestCase {
         } catch {
             XCTFail("Unable to create or deserialize data")
         }
-    }
-}
-
-final class MockMappableObject: BasicMappable {
-    var identifier: String = ""
-    var name: String = ""
-
-    func sequence(_ map: Map) throws {
-        try identifier <~ map["identifier"]
-        try name <~ map["name"]
     }
 }

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -62,4 +62,9 @@ class AuthenticationTests: XCTestCase {
         }
     }
 
+    func testCredentialProviderAuthorizedRequest() {
+        var testRequest = TestRequest().urlRequest
+        credentialProvider.authorizeRequest(&testRequest)
+        XCTAssertEqual(testRequest.value(forHTTPHeaderField: "Authorization"), credentialProvider.formattedToken)
+    }
 }

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -1,0 +1,65 @@
+//
+//  AuthenticationTests.swift
+//  APIClient
+//
+//  Created by Mark Daigneault on 3/6/17.
+//  Copyright © 2017 Mark Daigneault. All rights reserved.
+//
+
+import XCTest
+@testable import APIClient
+
+class AuthenticationTests: XCTestCase {
+
+    let apiClient = MockAPIClient()
+    let authClient = MockAuthClient()
+    let credentialProvider = MockCredentialProvider()
+
+    var sut: AuthTokenRefresher!
+
+    override func setUp() {
+        super.setUp()
+
+        sut = AuthTokenRefresher(apiClient: apiClient, authClient: authClient, credentialProvider: credentialProvider)
+    }
+    
+    override func tearDown() {
+        sut = nil
+
+        super.tearDown()
+    }
+
+    func testAuthTokenRefreshSuccess() {
+        let testRequest = TestRequest().urlRequest
+
+        apiClient.success = true
+        authClient.success = true
+
+        sut.handleUnauthorizedRequest(request: testRequest) { [weak self] result in
+            XCTAssertEqual(self?.credentialProvider.token, "token")
+            XCTAssert(result.isSuccess)
+        }
+    }
+
+    func testAuthTokenRefreshAPIClientFailure() {
+        let testRequest = TestRequest().urlRequest
+
+        // Token refresh succeeds, subsequest request fails
+        apiClient.success = false
+        authClient.success = true
+
+        sut.handleUnauthorizedRequest(request: testRequest) { [weak self] result in
+            XCTAssertEqual(self?.credentialProvider.token, "token")
+            XCTAssert(result.isFailure)
+        }
+
+        // Token refresh fails
+        authClient.success = false
+
+        sut.handleUnauthorizedRequest(request: testRequest) { [weak self] result in
+            XCTAssertNil(self?.credentialProvider.token)
+            XCTAssert(result.isFailure)
+        }
+    }
+
+}

--- a/Tests/Mocks/MockAPIClient.swift
+++ b/Tests/Mocks/MockAPIClient.swift
@@ -1,0 +1,24 @@
+//
+//  MockAPIClient.swift
+//  APIClient
+//
+//  Created by Mark Daigneault on 3/6/17.
+//  Copyright © 2017 Mark Daigneault. All rights reserved.
+//
+
+import Foundation
+import Intrepid
+@testable import APIClient
+
+class MockAPIClient: APIClient {
+
+    var success: Bool = true
+
+    override func sendRequest(_ request: URLRequest, completion: ((Result<Data?>) -> Void)?) {
+        if success {
+            completion?(.success(nil))
+        } else {
+            completion?(.failure(APIClientError.unknown))
+        }
+    }
+}

--- a/Tests/Mocks/MockAuthClient.swift
+++ b/Tests/Mocks/MockAuthClient.swift
@@ -1,0 +1,23 @@
+//
+//  MockAuthClient.swift
+//  APIClient
+//
+//  Created by Mark Daigneault on 3/6/17.
+//  Copyright © 2017 Mark Daigneault. All rights reserved.
+//
+
+import Foundation
+import Intrepid
+@testable import APIClient
+
+class MockAuthClient: AuthClient {
+    var success: Bool = true
+
+    func login(email: String, password: String, completion: ((Result<String>) -> Void)?) {
+        if success {
+            completion?(.success("token"))
+        } else {
+            completion?(.failure(APIClientError.unknown))
+        }
+    }
+}

--- a/Tests/Mocks/MockMappableObject.swift
+++ b/Tests/Mocks/MockMappableObject.swift
@@ -1,0 +1,20 @@
+//
+//  MockMappableObject.swift
+//  APIClient
+//
+//  Created by Mark Daigneault on 3/6/17.
+//  Copyright © 2017 Mark Daigneault. All rights reserved.
+//
+
+import Foundation
+import Genome
+
+final class MockMappableObject: BasicMappable {
+    var identifier: String = ""
+    var name: String = ""
+
+    func sequence(_ map: Map) throws {
+        try identifier <~ map["identifier"]
+        try name <~ map["name"]
+    }
+}

--- a/Tests/Mocks/MockRequest.swift
+++ b/Tests/Mocks/MockRequest.swift
@@ -1,0 +1,96 @@
+//
+//  MockRequest.swift
+//  APIClient
+//
+//  Created by Mark Daigneault on 3/6/17.
+//  Copyright © 2017 Mark Daigneault. All rights reserved.
+//
+
+import Foundation
+@testable import APIClient
+
+struct TestRequest: Request {
+
+    static var baseURL: String {
+        return "http://www.intrepid.io"
+    }
+
+    static var acceptHeader: String? {
+        return "application/json"
+    }
+
+    var method: HTTPMethod {
+        return .GET
+    }
+
+    var path: String {
+        return "test"
+    }
+
+    var authenticated: Bool {
+        return true
+    }
+
+    var queryParameters: [String : Any]? {
+        return [
+            "param1" : "1",
+            "param2" : "2"
+        ]
+    }
+
+    var bodyParameters: [String : Any]? {
+        return [
+            "object" : [
+                "id" : "1",
+                "name" : "test"
+            ]
+        ]
+    }
+
+    var contentType: String {
+        return "application/json"
+    }
+
+    var credentialProvider: CredentialProviding {
+        return MockCredentialProvider()
+    }
+}
+
+class MockCredentialProvider: CredentialProviding {
+    var email: String? {
+        get {
+            return "markd@intrepid.io"
+        }
+        set {
+
+        }
+    }
+
+    var password: String? {
+        get {
+            return "Intrepid11!"
+        }
+        set {
+
+        }
+    }
+
+    private var _token: String?
+
+    var token: String? {
+        get {
+            return _token
+        }
+        set {
+            _token = newValue
+        }
+    }
+
+    var formattedToken: String? {
+        if let token = token {
+            return "Token token=\(token)"
+        } else {
+            return nil
+        }
+    }
+}

--- a/Tests/Mocks/MockRequest.swift
+++ b/Tests/Mocks/MockRequest.swift
@@ -51,7 +51,7 @@ struct TestRequest: Request {
         return "application/json"
     }
 
-    var credentialProvider: CredentialProviding {
+    var credentialProvider: CredentialProviding? {
         return MockCredentialProvider()
     }
 }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -9,53 +9,6 @@
 import XCTest
 @testable import APIClient
 
-struct TestRequest: Request {
-
-    static var baseURL: String {
-        return "http://www.intrepid.io"
-    }
-
-    static var acceptHeader: String? {
-        return "application/json"
-    }
-
-    static var authorizationHeader: String? {
-        return "test-token"
-    }
-
-    var method: HTTPMethod {
-        return .GET
-    }
-
-    var path: String {
-        return "test"
-    }
-
-    var authenticated: Bool {
-        return true
-    }
-
-    var queryParameters: [String : Any]? {
-        return [
-            "param1" : "1",
-            "param2" : "2"
-        ]
-    }
-
-    var bodyParameters: [String : Any]? {
-        return [
-            "object" : [
-                "id" : "1",
-                "name" : "test"
-            ]
-        ]
-    }
-
-    var contentType: String {
-        return "application/json"
-    }
-}
-
 class RequestTests: XCTestCase {
 
     let testRequest = TestRequest()
@@ -94,6 +47,6 @@ class RequestTests: XCTestCase {
         let headers = sut.allHTTPHeaderFields
         XCTAssertEqual(headers?["Accept"], TestRequest.acceptHeader)
         XCTAssertEqual(headers?["Content-Type"], testRequest.contentType)
-        XCTAssertEqual(headers?["Authorization"], "\(TestRequest.authorizationHeader!)")
+        XCTAssertEqual(headers?["Authorization"], testRequest.credentialProvider.formattedToken)
     }
 }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -47,6 +47,6 @@ class RequestTests: XCTestCase {
         let headers = sut.allHTTPHeaderFields
         XCTAssertEqual(headers?["Accept"], TestRequest.acceptHeader)
         XCTAssertEqual(headers?["Content-Type"], testRequest.contentType)
-        XCTAssertEqual(headers?["Authorization"], testRequest.credentialProvider.formattedToken)
+        XCTAssertEqual(headers?["Authorization"], testRequest.credentialProvider?.formattedToken)
     }
 }


### PR DESCRIPTION
Adds several components in order to provide token refresh functionality
- `AuthClient`: A protocol defining an email/password login function, with a token result closure
- `CredentialProviding`: A protocol for objects that handle persistence of auth credentials and token. Also handles configuration of requests with current token value (this functionality is used in both the initial request builder and token refresher)
- `AuthTokenRefresher`: Defines a function for handling an unauthorized (401) response by re-logging in with saved credentials, configuring the original request with the new token, and retrying the request.