### PR TITLE
Mapping Fixes

### DIFF
--- a/Source/APIClient/APIClient.swift
+++ b/Source/APIClient/APIClient.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Intrepid
 
-enum APIClientError: Error {
+public enum APIClientError: Error {
     case httpError(statusCode: Int, response: HTTPURLResponse, data: Data?)
     case dataTaskError(error: Error)
     case unableToMapResult

--- a/Source/APIClientGenome/APIClient+Genome.swift
+++ b/Source/APIClientGenome/APIClient+Genome.swift
@@ -34,16 +34,16 @@ public extension APIClient {
 
     // MARK: - Singular Result Type
 
-    public func sendRequest<T: MappableObject>(_ request: URLRequest, keyPath: String? = nil, completion: ((Result<T>) -> Void)?) {
+    public func sendRequest<T: NodeInitializable>(_ request: URLRequest, keyPath: String? = nil, completion: ((Result<T>) -> Void)?) {
         let dataRequestCompletion: (Result<Data?>) -> Void = { dataResult in
             DispatchQueue.main.async{
-                completion?(self.mappableObjectResult(keyPath: keyPath, dataResult: dataResult))
+                completion?(self.nodeInitializableResult(keyPath: keyPath, dataResult: dataResult))
             }
         }
         sendRequest(request, completion: dataRequestCompletion)
     }
 
-    internal func mappableObjectResult<T: MappableObject>(keyPath: String?, dataResult: Result<Data?>) -> Result<T> {
+    internal func nodeInitializableResult<T: NodeInitializable>(keyPath: String?, dataResult: Result<Data?>) -> Result<T> {
         var result: Result<T>
 
         switch dataResult {
@@ -69,16 +69,16 @@ public extension APIClient {
 
     // MARK: - Array Result Type
 
-    public func sendRequest<T: MappableObject>(_ request: URLRequest, keyPath: String? = nil, completion: ((Result<[T]>) -> Void)?) {
+    public func sendRequest<T: NodeInitializable>(_ request: URLRequest, keyPath: String? = nil, completion: ((Result<[T]>) -> Void)?) {
         let dataRequestCompletion: (Result<Data?>) -> Void = { dataResult in
             DispatchQueue.main.async{
-                completion?(self.mappableArrayResult(keyPath: keyPath, dataResult: dataResult))
+                completion?(self.nodeInitializableArrayResult(keyPath: keyPath, dataResult: dataResult))
             }
         }
         sendRequest(request, completion: dataRequestCompletion)
     }
 
-    internal func mappableArrayResult<T: MappableObject>(keyPath: String?, dataResult: Result<Data?>) -> Result<[T]> {
+    internal func nodeInitializableArrayResult<T: NodeInitializable>(keyPath: String?, dataResult: Result<Data?>) -> Result<[T]> {
         var result: Result<[T]>
 
         switch dataResult {
@@ -103,5 +103,4 @@ public extension APIClient {
 
         return result
     }
-
 }

--- a/Tests/APIClientTests.swift
+++ b/Tests/APIClientTests.swift
@@ -59,10 +59,49 @@ class APIClientTests: XCTestCase {
         let json = ["identifier" : "1", "name" : "test"]
         do {
             let data = try JSONSerialization.data(withJSONObject: json, options: [])
-            let success: Result<MockMappableObject> = sut.mappableObjectResult(keyPath: nil, dataResult: .success(data))
+            let success: Result<MockMappableObject> = sut.nodeInitializableResult(keyPath: nil, dataResult: .success(data))
             let mappedObject = success.value
             XCTAssertEqual(mappedObject?.identifier, "1")
             XCTAssertEqual(mappedObject?.name, "test")
+        } catch {
+            XCTFail("Unable to create or deserialize data")
+        }
+    }
+
+    func testSingularStringResult() {
+        let key = "string"
+        let value = "some string"
+        let json = [key : value]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: json, options: [])
+            let success: Result<String> = sut.nodeInitializableResult(keyPath: key, dataResult: .success(data))
+            XCTAssertEqual(success.value, value)
+        } catch {
+            XCTFail("Unable to create or deserialize data")
+        }
+    }
+
+    func testSingularNumberResult() {
+        let key = "number"
+        let value = 1.5
+        let json = [key : value]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: json, options: [])
+            let success: Result<Double> = sut.nodeInitializableResult(keyPath: key, dataResult: .success(data))
+            XCTAssertEqual(success.value, value)
+        } catch {
+            XCTFail("Unable to create or deserialize data")
+        }
+    }
+
+    func testSingularBoolResult() {
+        let key = "bool"
+        let value = true
+        let json = [key : value]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: json, options: [])
+            let success: Result<Bool> = sut.nodeInitializableResult(keyPath: key, dataResult: .success(data))
+            XCTAssertEqual(success.value, value)
         } catch {
             XCTFail("Unable to create or deserialize data")
         }
@@ -75,7 +114,7 @@ class APIClientTests: XCTestCase {
         ]
         do {
             let data = try JSONSerialization.data(withJSONObject: json, options: [])
-            let success: Result<[MockMappableObject]> = sut.mappableArrayResult(keyPath: nil, dataResult: .success(data))
+            let success: Result<[MockMappableObject]> = sut.nodeInitializableArrayResult(keyPath: nil, dataResult: .success(data))
             let array = success.value
             XCTAssertEqual(array?[0].identifier, "1")
             XCTAssertEqual(array?[0].name, "test")


### PR DESCRIPTION
- Switch to using `NodeInitializable` protocol as mappable function generic requirement
    - This allows us to map to primitive types, which conform to `NodeInitializable` already in Genome
- Make APIClientError public